### PR TITLE
Fix typo in onclick event handler setup code for timestamp links

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -1062,7 +1062,7 @@ var Renderer = {
       footer.appendChild(Renderer.makeText(" "));
     }
     if(tweetManager.isRetweet(tweet.id)) {
-      footer.appendChild(chrome.i18n.getMessage("retweetedByMe") + ' ');
+      footer.appendChild(Renderer.makeText(chrome.i18n.getMessage("retweetedByMe") + ' '));
     }
     if(from) {
       var span = Renderer.makeElem("span", {class:"from_app"});

--- a/popup.html
+++ b/popup.html
@@ -1046,7 +1046,7 @@ var Renderer = {
     statusLinkSpan.appendChild(Renderer.makeText(Renderer.getTimestampText(tweet.created_at)));
     var statusLink = Renderer.makeElem("a", {href:'#'});
     statusLink.appendChild(statusLinkSpan);
-    statusLink.onClick = function() {openTab(statusLinkDst);};
+    statusLink.onclick = function() {openTab(statusLinkDst);};
 
     footer.appendChild(statusLink);
     footer.appendChild(Renderer.makeText(" "));


### PR DESCRIPTION
The previous patch to fix the HTML injection bug contained a typo resulting in the timestamp links in the timeline not being functional. This patch fixes it.
