### PR TITLE
img.ur preview image support

### DIFF
--- a/lib/image_services.js
+++ b/lib/image_services.js
@@ -222,6 +222,10 @@ ImageService.addService('pict.mobi', {
   }
 });
 
+ImageService.addService('i.imgur.com', {
+  thumb: 'http://i.imgur.com/$1',
+});
+
 ImageService.addService('movapic.com', {
   thumb: function(path) { return 'http://image.movapic.com/pic/t_' + path.split('/')[1] + '.jpeg'; }
 });


### PR DESCRIPTION
Added base functionality for img.ur support, the $1 needs to be rewritten to show filenames.ext instead of filename.ext. Take note of the s added to the filename.
