### PR TITLE
Image Upload Logic

### DIFF
--- a/lib/image_services.js
+++ b/lib/image_services.js
@@ -222,6 +222,10 @@ ImageService.addService('pict.mobi', {
   }
 });
 
+ImageService.addService('i.imgur.com', {
+  thumb: 'http://i.imgur.com/$1',
+});
+
 ImageService.addService('movapic.com', {
   thumb: function(path) { return 'http://image.movapic.com/pic/t_' + path.split('/')[1] + '.jpeg'; }
 });


### PR DESCRIPTION
I have noticed the logic for how the image upload works.  The upload should take place during the "Tweet It!" and not before.  By uploading images before the tweet is posted it is not sending the attached message to image service. I would think its best if they select the image, and instead of it instantly uploading it should hold it as a temp file until the "Tweet It!" is pressed. Once pressed it can send the message and the image to the image service.
