### PR TITLE
Images are being expanded even if its' URLs was shortened

### DIFF
--- a/lib/tweets_assembler.js
+++ b/lib/tweets_assembler.js
@@ -89,13 +89,7 @@ var Renderer = {
     });
   },
 
-  expandLink: function (aElement, url) {
-    if(this.isOnPage()) {
-      return;
-    }
-    if(!OptionsBackend.get('show_expanded_urls')) {
-      return;
-    }
+  expandImageLink: function (aElement, url) {
     var thumbUrl = ImageService.getThumb(url);
     if(thumbUrl) {
       $(aElement).tipsy({
@@ -108,6 +102,20 @@ var Renderer = {
         opacity: 1.0,
         gravity: $.fn.tipsy.autoWE
       });
+      return true;
+    } else {
+      return false;
+    }
+  },
+
+  expandLink: function (aElement, url) {
+    if(this.isOnPage()) {
+      return;
+    }
+    if(!OptionsBackend.get('show_expanded_urls')) {
+      return;
+    }
+    if(Renderer.expandImageLink(aElement, url)) {
       return;
     }
     $(aElement).tipsy({
@@ -122,6 +130,9 @@ var Renderer = {
       function expanded(success, isShortened, longUrl) {
         if(!isShortened) {
           $(aElement).tipsy({hideNow: true});
+          return;
+        }
+        if(Renderer.expandImageLink(aElement, longUrl)) {
           return;
         }
         $(aElement).tipsy({


### PR DESCRIPTION
Bloody t.co shortener hides links to images hosted on twitpic, img.ly, etc. It happends automatically if you use native Twitter (former Tweetie) applications for iOS or MacOS X.
So, when expander saw t.co-shortened link it just expanded the link and user was meant to go on the due image hosting and look at the picture in their browser instead of seeing a beautiful thumbnail in the Silver Bird.

I believe, that's a good feature to pull.
