### PR TITLE
Iteratively expand shortened URLs.

### DIFF
--- a/lib/tweets_assembler.js
+++ b/lib/tweets_assembler.js
@@ -126,11 +126,17 @@ var Renderer = {
       showNow: true,
       gravity: $.fn.tipsy.autoWE
     });
+    var wasShortened = false;
     urlExpander.expand(url,
       function expanded(success, isShortened, longUrl) {
-        if(!isShortened) {
+        if(!isShortened && !wasShortened) {
           $(aElement).tipsy({hideNow: true});
           return;
+        }
+        if (success && isShortened) {
+            wasShortened = true;
+            urlExpander.expand(longUrl, expanded);
+            return;
         }
         if(Renderer.expandImageLink(aElement, longUrl)) {
           return;


### PR DESCRIPTION
Iteratively expand shortened URLs on hover, to handle double-shortened URLs. (This is fairly common when Twitter's t.co shortening service is used.)

Patch for issue #290: https://github.com/cezarsa/silver_bird/issues/290
