### PR TITLE
simplify url parsing thanks to t.co

### DIFF
--- a/lib/tweets_assembler.js
+++ b/lib/tweets_assembler.js
@@ -155,19 +155,11 @@ var Renderer = {
 
   transformTweetText: Transforms.transformFactory([
       {
-        //create links (based on John Gruber's pattern from
-        //http://daringfireball.net/2009/11/liberal_regex_for_matching_urls
-        //
-        //I wish JavaScript had character classes
-        'expression': /\b((([\w-]+):\/\/?|www[.])[^\s()<>]+((\([\w\d]+\))|([^,.;:'"`~\s]|\/)))/i,
+        //since twitter is using t.co to "hide" urls
+        'expression': /\bhttp:\/\/t.co\/\w+/i,
         'replacement': function() {
           var url = RegExp.$1;
           var scheme = RegExp.$3;
-
-          if (scheme && !(/^(https?|ftp)$/i.exec(scheme))) {
-            // possibly dangerous scheme, suppress it
-            return document.createTextNode(url);
-          }
 
           var hrefObj = document.createElement("a");
           hrefObj.setAttribute("href", url);


### PR DESCRIPTION
Since twitter is using their t.co url shortener. No need to have a complex regex anymore. And also, because I'm regulary having "this url does not exists" since your regex matches characters like ! or brackets.
