### PR TITLE
Disable notification anim

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -704,6 +704,9 @@
 	"l_notify_rt_never": {
 	  "message": "Never"
 	},
+    "l_disable_notification_animation": {
+      "message":" Disable Timeout Animation (fix issues on multimonitor):"
+    },
 	"invalid_keys": {
 	  "message": "You are using empty API keys. This is probably happening because you're running a development version.<br>You should register an application at http://dev.twitter.com and fill the API keys in the lib/secret_keys.js file."
 	}

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -704,6 +704,10 @@
 	"l_notify_rt_never": {
 	  "message": "Mai"
 	},
+    "l_disable_notification_animation": {
+      "message": "Disabilita animazione del timeout (risolve problemi con multimonitor):"
+    },
+
 	"invalid_keys": {
 	  "message": "Stai usando delle API key vuote, probabilmente perché stai utilizzando una versione in via di sviluppo.<br>È preferibile registrare le applicazioni su http://dev.twitter.com e riempire le APi key nel file lib/secret_keys.jso."
 	}

--- a/lib/notifier/init.js
+++ b/lib/notifier/init.js
@@ -26,7 +26,13 @@ setTimeout(function() {
   };
   if (disableAnimation)
   {
-    setTimeout(closefn,fadeTimeout);
+    $('#progress').show().css('bottom','0px').css('width','100%');
+    var tmout=setTimeout(closefn,fadeTimeout);
+    $(document.body).click(function()
+    {
+        clearTimeout(tmout);
+        $('#progress').hide();
+    });
   } else
   {
       $('#progress').show().css('bottom', '0px').css('width', '100%').

--- a/lib/notifier/init.js
+++ b/lib/notifier/init.js
@@ -6,6 +6,7 @@ var ImageService = chrome.extension.getBackgroundPage().ImageService;
 chrome.i18n.getMessage = chrome.extension.getBackgroundPage().chrome.i18n.getMessage;
 
 var fadeTimeout = OptionsBackend.get('notification_fade_timeout');
+var disableAnimation = OptionsBackend.get('disable_notification_animation');
 
 try {
   var tweet = tweetManager.injectTweets.shift();
@@ -18,15 +19,21 @@ try {
 
 setTimeout(function() {
   $("#progress").text(chrome.i18n.getMessage("preventClosing"));
-  $('#progress').show().css('bottom', '0px').css('width', '100%').
-      animate({width: '0px'}, fadeTimeout, 'linear', function() {
+  var closefn = function() {
     // Tell manager that this tweet shouldn't be marked as read
     tweetManager.shouldNotReadMap[tweet.id] = true;
     window.close();
-  });
-
-  $(document.body).click(function() {
-    $('#progress').stop().hide();
-  });
+  };
+  if (disableAnimation)
+  {
+    setTimeout(closefn,fadeTimeout);
+  } else
+  {
+      $('#progress').show().css('bottom', '0px').css('width', '100%').
+          animate({width: '0px'}, fadeTimeout, 'linear', closefn);
+      $(document.body).click(function() {
+        $('#progress').stop().hide();
+      });
+  }
 }, 100);
 

--- a/lib/options_backend.js
+++ b/lib/options_backend.js
@@ -88,6 +88,7 @@ OptionsBackend = {
     search_tweets_color: 'rgba(0, 0, 0, 0)',
 
     notify_retweets: 'only_first',
+    disable_notification_animation: false,
     notification_fade_timeout: 6000,
     theme: 'css/chromified.css,css/chromified-theme/jquery-ui-1.7.2.custom.css',
     font_family: 'Helvetica, Arial, sans-serif',

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "Silver Bird",
+    "name": "Silver Bird -custom",
     "version": "1.9.9.1",
     "manifest_version": 2,
     "description": "__MSG_extDescription__",

--- a/options.html
+++ b/options.html
@@ -179,6 +179,8 @@
     <input type="radio" name="notify_retweets" value="always" id="notify_rt_always"> <label for="notify_rt_always" class="radio_opt i18n" id="l_notify_rt_always">Always</label>
     <input type="radio" name="notify_retweets" value="only_first" id="notify_rt_only_first"> <label for="notify_rt_only_first" class="radio_opt i18n" id="l_notify_rt_only_first">First One Only</label>
     <input type="radio" name="notify_retweets" value="never" id="notify_rt_never"> <label for="notify_rt_never" class="radio_opt i18n" id="l_notify_rt_never">Never</label><br>
+    <label for="disable_notification_animation" class="i18n" id="l_disable_notification_animation">Disable Timeout Animation (fix issues on multimonitor):</label>
+    <input type="checkbox" id="disable_notification_animation" name="disable_notification_animation" /><br/>
 
   </fieldset>
 


### PR DESCRIPTION
this fix introduce a new configuration option to disable jQuery-based
animation for sliding bar in notification popup. The animation generate
a bad issue on multimonitor with notification that stuck between
screens.
