### PR TITLE
Show thumbnails from pbs.twimg.com.

### DIFF
--- a/lib/image_services.js
+++ b/lib/image_services.js
@@ -278,3 +278,7 @@ ImageService.addService('lockerz.com', {
 ImageService.addService('p.twimg.com', {
   thumb: '$2:thumb'
 });
+
+ImageService.addService('pbs.twimg.com', {
+  thumb: '$2:thumb'
+});


### PR DESCRIPTION
Just as it says, show thumbnails from pbs.twimg.com. All the media entities in my timeline seems to use this, so none of the pic.twitter.com links shows any thumbnails without it.
