### PR TITLE
Avoid mentions of similar twitter accounts in own timeline

### DIFF
--- a/lib/timelines/timeline.js
+++ b/lib/timelines/timeline.js
@@ -232,7 +232,7 @@ TweetsTimeline.prototype = {
   _handleStreamData: function(data) {
     var tweets;
     if(data.text) {
-      var mentionStr = '@' + this.manager.twitterBackend.username();
+      var mentionStr = '@' + this.manager.twitterBackend.username() + '\\b';
       if(data.text.match(mentionStr)) {
         if(this.template.id == TimelineTemplate.MENTIONS) {
           tweets = [data];


### PR DESCRIPTION
Currently, if there is a tweet for a mention for an account that starts like the own account, it is shown in the own timeline.
For example:
- own account: @man
- tweet: "@manifold ideas" is shown
  This should be excluded. Therefore I adapted the regex to match a word boundary after the own username. Tested for my own and works.
